### PR TITLE
Support board GA401IH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "rog_fan_curve"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "serde_json",

--- a/rog_fan_curve/Cargo.toml
+++ b/rog_fan_curve/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rog_fan_curve"
-version = "0.1.7"
+version = "0.1.8"
 authors = ["ryan <yarnnd@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Yarn/rog_fan_curve"

--- a/rog_fan_curve/src/lib.rs
+++ b/rog_fan_curve/src/lib.rs
@@ -311,6 +311,7 @@ impl Board {
             "GA401IU" => Some(Board::Ga401),
             "GA401II" => Some(Board::Ga401),
             "GA401IVC" => Some(Board::Ga401),
+            "GA401IH" => Some(Board::Ga401),
             _ => None,
         }
     }


### PR DESCRIPTION
GA401IH refers to laptops with Ryzen 4600HS CPU and GTX 1650 GPU
https://rog.asus.com/in/laptops/rog-zephyrus/rog-zephyrus-g14-series/spec