### PR TITLE
Support board GA401QM

### DIFF
--- a/rog_fan_curve/src/lib.rs
+++ b/rog_fan_curve/src/lib.rs
@@ -312,6 +312,7 @@ impl Board {
             "GA401II" => Some(Board::Ga401),
             "GA401IVC" => Some(Board::Ga401),
             "GA401IH" => Some(Board::Ga401),
+            "GA401QM" => Some(Board::Ga401),
             _ => None,
         }
     }


### PR DESCRIPTION
Tested it and works fine on my 2021 G14 (GA401QM-K2023T)